### PR TITLE
Updated typekit package.xml and changelog for 0.1.1 release

### DIFF
--- a/typekits/rtt_control_msgs/CHANGELOG.rst
+++ b/typekits/rtt_control_msgs/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package rtt_control_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.1.1 (2017-12-14)
+------------------
+* Cleanup typekits and remove unneccessary dependencies
+* Merge pull request `#1 <https://github.com/orocos/rtt_ros_control/issues/1>`_ from Timple/master
+  Package does not depend on controller_manager_msgs
+* Contributors: Johannes Meyer, Jonathan Bohren, Tim Clephas
+
 0.1.0 (2014-12-08)
 ------------------
 * updating typekit cmakelists

--- a/typekits/rtt_control_msgs/package.xml
+++ b/typekits/rtt_control_msgs/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>rtt_control_msgs</name>
-  <version>0.1.0</version>
+  <version>0.1.1</version>
   <description>
 
     Provides an rtt typekit for ROS control_msgs messages.

--- a/typekits/rtt_control_msgs/package.xml
+++ b/typekits/rtt_control_msgs/package.xml
@@ -3,7 +3,7 @@
   <version>0.1.0</version>
   <description>
 
-    Provides an rtt typekit for ROS ros_controls messages.
+    Provides an rtt typekit for ROS control_msgs messages.
 
     It allows you to use ROS messages transparently in
     RTT components and applications.
@@ -12,23 +12,20 @@
     create_rtt_msgs generator and should not be manually
     modified.
 
-    See the http://ros.org/wiki/actionlib_msgs documentation
+    See the http://ros.org/wiki/control_msgs documentation
     for the documentation of the ROS messages in this
     typekit.
 
   </description>
   <maintainer email="orocos-dev@lists.mech.kuleuven.be">Orocos Developers</maintainer>
-  <author>create_rtt_msgs</author>
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>control_msgs</build_depend>
-  <build_depend>control_toolbox</build_depend>
   <build_depend>rtt_roscomm</build_depend>
 
   <run_depend>control_msgs</run_depend>
-  <run_depend>control_toolbox</run_depend>
   <run_depend>rtt_roscomm</run_depend>
 
   <build_depend>rtt_std_msgs</build_depend>

--- a/typekits/rtt_controller_manager_msgs/CHANGELOG.rst
+++ b/typekits/rtt_controller_manager_msgs/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package rtt_controller_manager_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.1.1 (2017-12-14)
+------------------
+* Cleanup typekits and remove unneccessary dependencies
+* Contributors: Johannes Meyer
+
 0.1.0 (2014-12-08)
 ------------------
 * updating typekit cmakelists

--- a/typekits/rtt_controller_manager_msgs/CMakeLists.txt
+++ b/typekits/rtt_controller_manager_msgs/CMakeLists.txt
@@ -8,5 +8,5 @@ ros_generate_rtt_service_proxies(controller_manager_msgs)
 
 orocos_generate_package(
   DEPENDS controller_manager_msgs
-  DEPENDS_TARGETS rtt_roscomm rtt_std_msgs rtt_geometry_msgs rtt_trajectory_msgs rtt_actionlib_msgs
+  DEPENDS_TARGETS rtt_roscomm rtt_std_msgs
 )

--- a/typekits/rtt_controller_manager_msgs/package.xml
+++ b/typekits/rtt_controller_manager_msgs/package.xml
@@ -3,7 +3,7 @@
   <version>0.1.0</version>
   <description>
 
-    Provides an rtt typekit for ROS ros_controls messages.
+    Provides an rtt typekit for ROS controller_manager_msgs messages.
 
     It allows you to use ROS messages transparently in
     RTT components and applications.
@@ -12,42 +12,29 @@
     create_rtt_msgs generator and should not be manually
     modified.
 
-    See the http://ros.org/wiki/actionlib_msgs documentation
+    See the http://ros.org/wiki/controller_manager_msgs documentation
     for the documentation of the ROS messages in this
     typekit.
 
   </description>
   <maintainer email="orocos-dev@lists.mech.kuleuven.be">Orocos Developers</maintainer>
-  <author>create_rtt_msgs</author>
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>controller_manager_msgs</build_depend>
-  <build_depend>control_toolbox</build_depend>
-  <build_depend>controller_manager_msgs</build_depend>
   <build_depend>rtt_roscomm</build_depend>
 
   <run_depend>controller_manager_msgs</run_depend>
-  <run_depend>control_toolbox</run_depend>
   <run_depend>rtt_roscomm</run_depend>
 
   <build_depend>rtt_std_msgs</build_depend>
-  <build_depend>rtt_geometry_msgs</build_depend>
-  <build_depend>rtt_trajectory_msgs</build_depend>
-  <build_depend>rtt_actionlib_msgs</build_depend>
   <run_depend>rtt_std_msgs</run_depend>
-  <run_depend>rtt_geometry_msgs</run_depend>
-  <run_depend>rtt_trajectory_msgs</run_depend>
-  <run_depend>rtt_actionlib_msgs</run_depend>
 
   <export>
     <rtt_ros>
       <plugin_depend>rtt_roscomm</plugin_depend>
       <plugin_depend>rtt_std_msgs</plugin_depend>
-      <plugin_depend>rtt_geometry_msgs</plugin_depend>
-      <plugin_depend>rtt_trajectory_msgs</plugin_depend>
-      <plugin_depend>rtt_actionlib_msgs</plugin_depend>
     </rtt_ros>
   </export>
 

--- a/typekits/rtt_controller_manager_msgs/package.xml
+++ b/typekits/rtt_controller_manager_msgs/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>rtt_controller_manager_msgs</name>
-  <version>0.1.0</version>
+  <version>0.1.1</version>
   <description>
 
     Provides an rtt typekit for ROS controller_manager_msgs messages.


### PR DESCRIPTION
I've taken the liberty of releasing the typekits into ROS kinetic from a fork at https://github.com/orocos/rtt_ros_control.git without waiting for a response in #2, because the two packages only contain generated code. I did a minor cleanup of `package.xml` and `CMakeLists.txt` files before.

rosdistro PR: https://github.com/ros/rosdistro/pull/16588